### PR TITLE
Add ncc to devDependency & refactor to use setFailed

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -1,22 +1,22 @@
 /******/ (() => { // webpackBootstrap
 /******/ 	var __webpack_modules__ = ({
 
-/***/ 7648:
+/***/ 2932:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
-const core = __nccwpck_require__(2810);
-const tc = __nccwpck_require__(8021);
+const core = __nccwpck_require__(2186);
+const tc = __nccwpck_require__(7784);
 const os = __nccwpck_require__(2037);
 const path = __nccwpck_require__(1017);
-const fs = __nccwpck_require__(8060);
-const fetch = __nccwpck_require__(5662);
+const fs = __nccwpck_require__(5630);
+const fetch = __nccwpck_require__(467);
 
 async function setup() {
-  const version = core.getInput('version');
-  const apiKey = core.getInput('baselime-api-key');
+  const version = core.getInput("version");
+  const apiKey = core.getInput("baselime-api-key");
 
   // Download the specific version of the tool, e.g. as a tarball
-  const { url } = getDownloadURL(version || await getLatestCLIVersion());
+  const { url } = getDownloadURL(version || (await getLatestCLIVersion()));
   const pathToTarball = await tc.downloadTool(url);
 
   // Extract the tarball onto the runner
@@ -42,16 +42,18 @@ function getPath() {
 
 async function getLatestCLIVersion() {
   try {
-    const res = await (await fetch("https://api.github.com/repos/baselime/cli/releases/latest")).json();
+    const res = await (
+      await fetch("https://api.github.com/repos/baselime/cli/releases/latest")
+    ).json();
     return res.tag_name.replace("v", "");
   } catch (error) {
-    console.error("There was an error getting the latest version of the Baselime CLI", { error });
-    throw error;
+    core.setFailed(
+      `There was an error getting the latest version of the Baselime CLI ${error}`
+    );
   }
 }
 
-
-module.exports = setup
+module.exports = setup;
 
 if (require.main === require.cache[eval('__filename')]) {
   setup();
@@ -60,7 +62,7 @@ if (require.main === require.cache[eval('__filename')]) {
 
 /***/ }),
 
-/***/ 5649:
+/***/ 7351:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -87,7 +89,7 @@ var __importStar = (this && this.__importStar) || function (mod) {
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.issue = exports.issueCommand = void 0;
 const os = __importStar(__nccwpck_require__(2037));
-const utils_1 = __nccwpck_require__(3069);
+const utils_1 = __nccwpck_require__(5278);
 /**
  * Commands
  *
@@ -159,7 +161,7 @@ function escapeProperty(s) {
 
 /***/ }),
 
-/***/ 2810:
+/***/ 2186:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -194,12 +196,12 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.getIDToken = exports.getState = exports.saveState = exports.group = exports.endGroup = exports.startGroup = exports.info = exports.notice = exports.warning = exports.error = exports.debug = exports.isDebug = exports.setFailed = exports.setCommandEcho = exports.setOutput = exports.getBooleanInput = exports.getMultilineInput = exports.getInput = exports.addPath = exports.setSecret = exports.exportVariable = exports.ExitCode = void 0;
-const command_1 = __nccwpck_require__(5649);
-const file_command_1 = __nccwpck_require__(7054);
-const utils_1 = __nccwpck_require__(3069);
+const command_1 = __nccwpck_require__(7351);
+const file_command_1 = __nccwpck_require__(717);
+const utils_1 = __nccwpck_require__(5278);
 const os = __importStar(__nccwpck_require__(2037));
 const path = __importStar(__nccwpck_require__(1017));
-const oidc_utils_1 = __nccwpck_require__(3050);
+const oidc_utils_1 = __nccwpck_require__(8041);
 /**
  * The code to exit an action
  */
@@ -484,17 +486,17 @@ exports.getIDToken = getIDToken;
 /**
  * Summary exports
  */
-var summary_1 = __nccwpck_require__(6179);
+var summary_1 = __nccwpck_require__(1327);
 Object.defineProperty(exports, "summary", ({ enumerable: true, get: function () { return summary_1.summary; } }));
 /**
  * @deprecated use core.summary
  */
-var summary_2 = __nccwpck_require__(6179);
+var summary_2 = __nccwpck_require__(1327);
 Object.defineProperty(exports, "markdownSummary", ({ enumerable: true, get: function () { return summary_2.markdownSummary; } }));
 /**
  * Path exports
  */
-var path_utils_1 = __nccwpck_require__(9191);
+var path_utils_1 = __nccwpck_require__(2981);
 Object.defineProperty(exports, "toPosixPath", ({ enumerable: true, get: function () { return path_utils_1.toPosixPath; } }));
 Object.defineProperty(exports, "toWin32Path", ({ enumerable: true, get: function () { return path_utils_1.toWin32Path; } }));
 Object.defineProperty(exports, "toPlatformPath", ({ enumerable: true, get: function () { return path_utils_1.toPlatformPath; } }));
@@ -502,7 +504,7 @@ Object.defineProperty(exports, "toPlatformPath", ({ enumerable: true, get: funct
 
 /***/ }),
 
-/***/ 7054:
+/***/ 717:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -533,8 +535,8 @@ exports.prepareKeyValueMessage = exports.issueFileCommand = void 0;
 /* eslint-disable @typescript-eslint/no-explicit-any */
 const fs = __importStar(__nccwpck_require__(7147));
 const os = __importStar(__nccwpck_require__(2037));
-const uuid_1 = __nccwpck_require__(3160);
-const utils_1 = __nccwpck_require__(3069);
+const uuid_1 = __nccwpck_require__(5840);
+const utils_1 = __nccwpck_require__(5278);
 function issueFileCommand(command, message) {
     const filePath = process.env[`GITHUB_${command}`];
     if (!filePath) {
@@ -567,7 +569,7 @@ exports.prepareKeyValueMessage = prepareKeyValueMessage;
 
 /***/ }),
 
-/***/ 3050:
+/***/ 8041:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -583,9 +585,9 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.OidcClient = void 0;
-const http_client_1 = __nccwpck_require__(1659);
-const auth_1 = __nccwpck_require__(9320);
-const core_1 = __nccwpck_require__(2810);
+const http_client_1 = __nccwpck_require__(6255);
+const auth_1 = __nccwpck_require__(5526);
+const core_1 = __nccwpck_require__(2186);
 class OidcClient {
     static createHttpClient(allowRetry = true, maxRetry = 10) {
         const requestOptions = {
@@ -651,7 +653,7 @@ exports.OidcClient = OidcClient;
 
 /***/ }),
 
-/***/ 9191:
+/***/ 2981:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -716,7 +718,7 @@ exports.toPlatformPath = toPlatformPath;
 
 /***/ }),
 
-/***/ 6179:
+/***/ 1327:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -1006,7 +1008,7 @@ exports.summary = _summary;
 
 /***/ }),
 
-/***/ 3069:
+/***/ 5278:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -1053,7 +1055,7 @@ exports.toCommandProperties = toCommandProperties;
 
 /***/ }),
 
-/***/ 4235:
+/***/ 1514:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -1089,7 +1091,7 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.getExecOutput = exports.exec = void 0;
 const string_decoder_1 = __nccwpck_require__(1576);
-const tr = __importStar(__nccwpck_require__(5576));
+const tr = __importStar(__nccwpck_require__(8159));
 /**
  * Exec a command.
  * Output will be streamed to the live console.
@@ -1163,7 +1165,7 @@ exports.getExecOutput = getExecOutput;
 
 /***/ }),
 
-/***/ 5576:
+/***/ 8159:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -1202,8 +1204,8 @@ const os = __importStar(__nccwpck_require__(2037));
 const events = __importStar(__nccwpck_require__(2361));
 const child = __importStar(__nccwpck_require__(2081));
 const path = __importStar(__nccwpck_require__(1017));
-const io = __importStar(__nccwpck_require__(9913));
-const ioUtil = __importStar(__nccwpck_require__(8039));
+const io = __importStar(__nccwpck_require__(7436));
+const ioUtil = __importStar(__nccwpck_require__(1962));
 const timers_1 = __nccwpck_require__(9512);
 /* eslint-disable @typescript-eslint/unbound-method */
 const IS_WINDOWS = process.platform === 'win32';
@@ -1788,7 +1790,7 @@ class ExecState extends events.EventEmitter {
 
 /***/ }),
 
-/***/ 9320:
+/***/ 5526:
 /***/ (function(__unused_webpack_module, exports) {
 
 "use strict";
@@ -1876,7 +1878,7 @@ exports.PersonalAccessTokenCredentialHandler = PersonalAccessTokenCredentialHand
 
 /***/ }),
 
-/***/ 1659:
+/***/ 6255:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -1914,8 +1916,8 @@ Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.HttpClient = exports.isHttps = exports.HttpClientResponse = exports.HttpClientError = exports.getProxyUrl = exports.MediaTypes = exports.Headers = exports.HttpCodes = void 0;
 const http = __importStar(__nccwpck_require__(3685));
 const https = __importStar(__nccwpck_require__(5687));
-const pm = __importStar(__nccwpck_require__(3833));
-const tunnel = __importStar(__nccwpck_require__(2264));
+const pm = __importStar(__nccwpck_require__(9835));
+const tunnel = __importStar(__nccwpck_require__(4294));
 var HttpCodes;
 (function (HttpCodes) {
     HttpCodes[HttpCodes["OK"] = 200] = "OK";
@@ -2488,7 +2490,7 @@ const lowercaseKeys = (obj) => Object.keys(obj).reduce((c, k) => ((c[k.toLowerCa
 
 /***/ }),
 
-/***/ 3833:
+/***/ 9835:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -2556,7 +2558,7 @@ exports.checkBypass = checkBypass;
 
 /***/ }),
 
-/***/ 8039:
+/***/ 1962:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -2740,7 +2742,7 @@ exports.getCmdPath = getCmdPath;
 
 /***/ }),
 
-/***/ 9913:
+/***/ 7436:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -2779,7 +2781,7 @@ const assert_1 = __nccwpck_require__(9491);
 const childProcess = __importStar(__nccwpck_require__(2081));
 const path = __importStar(__nccwpck_require__(1017));
 const util_1 = __nccwpck_require__(3837);
-const ioUtil = __importStar(__nccwpck_require__(8039));
+const ioUtil = __importStar(__nccwpck_require__(1962));
 const exec = util_1.promisify(childProcess.exec);
 const execFile = util_1.promisify(childProcess.execFile);
 /**
@@ -3088,7 +3090,7 @@ function copyFile(srcFile, destFile, force) {
 
 /***/ }),
 
-/***/ 713:
+/***/ 2473:
 /***/ (function(module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -3123,8 +3125,8 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports._readLinuxVersionFile = exports._getOsVersion = exports._findMatch = void 0;
-const semver = __importStar(__nccwpck_require__(9079));
-const core_1 = __nccwpck_require__(2810);
+const semver = __importStar(__nccwpck_require__(5911));
+const core_1 = __nccwpck_require__(2186);
 // needs to be require for core node modules to be mocked
 /* eslint @typescript-eslint/no-require-imports: 0 */
 const os = __nccwpck_require__(2037);
@@ -3223,7 +3225,7 @@ exports._readLinuxVersionFile = _readLinuxVersionFile;
 
 /***/ }),
 
-/***/ 4625:
+/***/ 8279:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -3258,7 +3260,7 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.RetryHelper = void 0;
-const core = __importStar(__nccwpck_require__(2810));
+const core = __importStar(__nccwpck_require__(2186));
 /**
  * Internal class for retries
  */
@@ -3313,7 +3315,7 @@ exports.RetryHelper = RetryHelper;
 
 /***/ }),
 
-/***/ 8021:
+/***/ 7784:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -3351,20 +3353,20 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.evaluateVersions = exports.isExplicitVersion = exports.findFromManifest = exports.getManifestFromRepo = exports.findAllVersions = exports.find = exports.cacheFile = exports.cacheDir = exports.extractZip = exports.extractXar = exports.extractTar = exports.extract7z = exports.downloadTool = exports.HTTPError = void 0;
-const core = __importStar(__nccwpck_require__(2810));
-const io = __importStar(__nccwpck_require__(9913));
+const core = __importStar(__nccwpck_require__(2186));
+const io = __importStar(__nccwpck_require__(7436));
 const fs = __importStar(__nccwpck_require__(7147));
-const mm = __importStar(__nccwpck_require__(713));
+const mm = __importStar(__nccwpck_require__(2473));
 const os = __importStar(__nccwpck_require__(2037));
 const path = __importStar(__nccwpck_require__(1017));
-const httpm = __importStar(__nccwpck_require__(1659));
-const semver = __importStar(__nccwpck_require__(9079));
+const httpm = __importStar(__nccwpck_require__(6255));
+const semver = __importStar(__nccwpck_require__(5911));
 const stream = __importStar(__nccwpck_require__(2781));
 const util = __importStar(__nccwpck_require__(3837));
 const assert_1 = __nccwpck_require__(9491);
-const v4_1 = __importDefault(__nccwpck_require__(997));
-const exec_1 = __nccwpck_require__(4235);
-const retry_helper_1 = __nccwpck_require__(4625);
+const v4_1 = __importDefault(__nccwpck_require__(7468));
+const exec_1 = __nccwpck_require__(1514);
+const retry_helper_1 = __nccwpck_require__(8279);
 class HTTPError extends Error {
     constructor(httpStatusCode) {
         super(`Unexpected HTTP response: ${httpStatusCode}`);
@@ -3985,7 +3987,7 @@ function _unique(values) {
 
 /***/ }),
 
-/***/ 9910:
+/***/ 7701:
 /***/ ((module) => {
 
 /**
@@ -4018,7 +4020,7 @@ module.exports = bytesToUuid;
 
 /***/ }),
 
-/***/ 6818:
+/***/ 7269:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 // Unique ID creation requires a high quality random # generator.  In node.js
@@ -4033,11 +4035,11 @@ module.exports = function nodeRNG() {
 
 /***/ }),
 
-/***/ 997:
+/***/ 7468:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
-var rng = __nccwpck_require__(6818);
-var bytesToUuid = __nccwpck_require__(9910);
+var rng = __nccwpck_require__(7269);
+var bytesToUuid = __nccwpck_require__(7701);
 
 function v4(options, buf, offset) {
   var i = buf && offset || 0;
@@ -4069,17 +4071,17 @@ module.exports = v4;
 
 /***/ }),
 
-/***/ 310:
+/***/ 9618:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
-const fs = __nccwpck_require__(2380)
+const fs = __nccwpck_require__(7758)
 const path = __nccwpck_require__(1017)
-const mkdirsSync = (__nccwpck_require__(568).mkdirsSync)
-const utimesMillisSync = (__nccwpck_require__(6543).utimesMillisSync)
-const stat = __nccwpck_require__(2320)
+const mkdirsSync = (__nccwpck_require__(8605).mkdirsSync)
+const utimesMillisSync = (__nccwpck_require__(2548).utimesMillisSync)
+const stat = __nccwpck_require__(3901)
 
 function copySync (src, dest, opts) {
   if (typeof opts === 'function') {
@@ -4246,18 +4248,18 @@ module.exports = copySync
 
 /***/ }),
 
-/***/ 1619:
+/***/ 8834:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
-const fs = __nccwpck_require__(2380)
+const fs = __nccwpck_require__(7758)
 const path = __nccwpck_require__(1017)
-const mkdirs = (__nccwpck_require__(568).mkdirs)
-const pathExists = (__nccwpck_require__(5525).pathExists)
-const utimesMillis = (__nccwpck_require__(6543).utimesMillis)
-const stat = __nccwpck_require__(2320)
+const mkdirs = (__nccwpck_require__(8605).mkdirs)
+const pathExists = (__nccwpck_require__(3835).pathExists)
+const utimesMillis = (__nccwpck_require__(2548).utimesMillis)
+const stat = __nccwpck_require__(3901)
 
 function copy (src, dest, opts, cb) {
   if (typeof opts === 'function' && !cb) {
@@ -4489,32 +4491,32 @@ module.exports = copy
 
 /***/ }),
 
-/***/ 5403:
+/***/ 1335:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
-const u = (__nccwpck_require__(838).fromCallback)
+const u = (__nccwpck_require__(9046).fromCallback)
 module.exports = {
-  copy: u(__nccwpck_require__(1619)),
-  copySync: __nccwpck_require__(310)
+  copy: u(__nccwpck_require__(8834)),
+  copySync: __nccwpck_require__(9618)
 }
 
 
 /***/ }),
 
-/***/ 9080:
+/***/ 6970:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
-const u = (__nccwpck_require__(838).fromPromise)
-const fs = __nccwpck_require__(7856)
+const u = (__nccwpck_require__(9046).fromPromise)
+const fs = __nccwpck_require__(1176)
 const path = __nccwpck_require__(1017)
-const mkdir = __nccwpck_require__(568)
-const remove = __nccwpck_require__(4119)
+const mkdir = __nccwpck_require__(8605)
+const remove = __nccwpck_require__(7357)
 
 const emptyDir = u(async function emptyDir (dir) {
   let items
@@ -4551,16 +4553,16 @@ module.exports = {
 
 /***/ }),
 
-/***/ 4141:
+/***/ 2164:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
-const u = (__nccwpck_require__(838).fromCallback)
+const u = (__nccwpck_require__(9046).fromCallback)
 const path = __nccwpck_require__(1017)
-const fs = __nccwpck_require__(2380)
-const mkdir = __nccwpck_require__(568)
+const fs = __nccwpck_require__(7758)
+const mkdir = __nccwpck_require__(8605)
 
 function createFile (file, callback) {
   function makeFile () {
@@ -4628,15 +4630,15 @@ module.exports = {
 
 /***/ }),
 
-/***/ 6301:
+/***/ 55:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
-const { createFile, createFileSync } = __nccwpck_require__(4141)
-const { createLink, createLinkSync } = __nccwpck_require__(5622)
-const { createSymlink, createSymlinkSync } = __nccwpck_require__(8884)
+const { createFile, createFileSync } = __nccwpck_require__(2164)
+const { createLink, createLinkSync } = __nccwpck_require__(3797)
+const { createSymlink, createSymlinkSync } = __nccwpck_require__(2549)
 
 module.exports = {
   // file
@@ -4659,18 +4661,18 @@ module.exports = {
 
 /***/ }),
 
-/***/ 5622:
+/***/ 3797:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
-const u = (__nccwpck_require__(838).fromCallback)
+const u = (__nccwpck_require__(9046).fromCallback)
 const path = __nccwpck_require__(1017)
-const fs = __nccwpck_require__(2380)
-const mkdir = __nccwpck_require__(568)
-const pathExists = (__nccwpck_require__(5525).pathExists)
-const { areIdentical } = __nccwpck_require__(2320)
+const fs = __nccwpck_require__(7758)
+const mkdir = __nccwpck_require__(8605)
+const pathExists = (__nccwpck_require__(3835).pathExists)
+const { areIdentical } = __nccwpck_require__(3901)
 
 function createLink (srcpath, dstpath, callback) {
   function makeLink (srcpath, dstpath) {
@@ -4731,15 +4733,15 @@ module.exports = {
 
 /***/ }),
 
-/***/ 1088:
+/***/ 3727:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
 const path = __nccwpck_require__(1017)
-const fs = __nccwpck_require__(2380)
-const pathExists = (__nccwpck_require__(5525).pathExists)
+const fs = __nccwpck_require__(7758)
+const pathExists = (__nccwpck_require__(3835).pathExists)
 
 /**
  * Function that returns two types of paths, one relative to symlink, and one
@@ -4838,13 +4840,13 @@ module.exports = {
 
 /***/ }),
 
-/***/ 3957:
+/***/ 8254:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
-const fs = __nccwpck_require__(2380)
+const fs = __nccwpck_require__(7758)
 
 function symlinkType (srcpath, type, callback) {
   callback = (typeof type === 'function') ? type : callback
@@ -4877,30 +4879,30 @@ module.exports = {
 
 /***/ }),
 
-/***/ 8884:
+/***/ 2549:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
-const u = (__nccwpck_require__(838).fromCallback)
+const u = (__nccwpck_require__(9046).fromCallback)
 const path = __nccwpck_require__(1017)
-const fs = __nccwpck_require__(7856)
-const _mkdirs = __nccwpck_require__(568)
+const fs = __nccwpck_require__(1176)
+const _mkdirs = __nccwpck_require__(8605)
 const mkdirs = _mkdirs.mkdirs
 const mkdirsSync = _mkdirs.mkdirsSync
 
-const _symlinkPaths = __nccwpck_require__(1088)
+const _symlinkPaths = __nccwpck_require__(3727)
 const symlinkPaths = _symlinkPaths.symlinkPaths
 const symlinkPathsSync = _symlinkPaths.symlinkPathsSync
 
-const _symlinkType = __nccwpck_require__(3957)
+const _symlinkType = __nccwpck_require__(8254)
 const symlinkType = _symlinkType.symlinkType
 const symlinkTypeSync = _symlinkType.symlinkTypeSync
 
-const pathExists = (__nccwpck_require__(5525).pathExists)
+const pathExists = (__nccwpck_require__(3835).pathExists)
 
-const { areIdentical } = __nccwpck_require__(2320)
+const { areIdentical } = __nccwpck_require__(3901)
 
 function createSymlink (srcpath, dstpath, type, callback) {
   callback = (typeof type === 'function') ? type : callback
@@ -4967,15 +4969,15 @@ module.exports = {
 
 /***/ }),
 
-/***/ 7856:
+/***/ 1176:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
 
 // This is adapted from https://github.com/normalize/mz
 // Copyright (c) 2014-2016 Jonathan Ong me@jongleberry.com and Contributors
-const u = (__nccwpck_require__(838).fromCallback)
-const fs = __nccwpck_require__(2380)
+const u = (__nccwpck_require__(9046).fromCallback)
+const fs = __nccwpck_require__(7758)
 
 const api = [
   'access',
@@ -5103,7 +5105,7 @@ if (typeof fs.realpath.native === 'function') {
 
 /***/ }),
 
-/***/ 8060:
+/***/ 5630:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
@@ -5111,33 +5113,33 @@ if (typeof fs.realpath.native === 'function') {
 
 module.exports = {
   // Export promiseified graceful-fs:
-  ...__nccwpck_require__(7856),
+  ...__nccwpck_require__(1176),
   // Export extra methods:
-  ...__nccwpck_require__(5403),
-  ...__nccwpck_require__(9080),
-  ...__nccwpck_require__(6301),
-  ...__nccwpck_require__(2797),
-  ...__nccwpck_require__(568),
-  ...__nccwpck_require__(8901),
-  ...__nccwpck_require__(1923),
-  ...__nccwpck_require__(5525),
-  ...__nccwpck_require__(4119)
+  ...__nccwpck_require__(1335),
+  ...__nccwpck_require__(6970),
+  ...__nccwpck_require__(55),
+  ...__nccwpck_require__(213),
+  ...__nccwpck_require__(8605),
+  ...__nccwpck_require__(1497),
+  ...__nccwpck_require__(1832),
+  ...__nccwpck_require__(3835),
+  ...__nccwpck_require__(7357)
 }
 
 
 /***/ }),
 
-/***/ 2797:
+/***/ 213:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
-const u = (__nccwpck_require__(838).fromPromise)
-const jsonFile = __nccwpck_require__(6966)
+const u = (__nccwpck_require__(9046).fromPromise)
+const jsonFile = __nccwpck_require__(8970)
 
-jsonFile.outputJson = u(__nccwpck_require__(1438))
-jsonFile.outputJsonSync = __nccwpck_require__(1601)
+jsonFile.outputJson = u(__nccwpck_require__(531))
+jsonFile.outputJsonSync = __nccwpck_require__(9421)
 // aliases
 jsonFile.outputJSON = jsonFile.outputJson
 jsonFile.outputJSONSync = jsonFile.outputJsonSync
@@ -5151,13 +5153,13 @@ module.exports = jsonFile
 
 /***/ }),
 
-/***/ 6966:
+/***/ 8970:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
-const jsonFile = __nccwpck_require__(1927)
+const jsonFile = __nccwpck_require__(6160)
 
 module.exports = {
   // jsonfile exports
@@ -5170,14 +5172,14 @@ module.exports = {
 
 /***/ }),
 
-/***/ 1601:
+/***/ 9421:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
-const { stringify } = __nccwpck_require__(2681)
-const { outputFileSync } = __nccwpck_require__(1923)
+const { stringify } = __nccwpck_require__(5902)
+const { outputFileSync } = __nccwpck_require__(1832)
 
 function outputJsonSync (file, data, options) {
   const str = stringify(data, options)
@@ -5190,14 +5192,14 @@ module.exports = outputJsonSync
 
 /***/ }),
 
-/***/ 1438:
+/***/ 531:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
-const { stringify } = __nccwpck_require__(2681)
-const { outputFile } = __nccwpck_require__(1923)
+const { stringify } = __nccwpck_require__(5902)
+const { outputFile } = __nccwpck_require__(1832)
 
 async function outputJson (file, data, options = {}) {
   const str = stringify(data, options)
@@ -5210,13 +5212,13 @@ module.exports = outputJson
 
 /***/ }),
 
-/***/ 568:
+/***/ 8605:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
-const u = (__nccwpck_require__(838).fromPromise)
-const { makeDir: _makeDir, makeDirSync } = __nccwpck_require__(2547)
+const u = (__nccwpck_require__(9046).fromPromise)
+const { makeDir: _makeDir, makeDirSync } = __nccwpck_require__(2751)
 const makeDir = u(_makeDir)
 
 module.exports = {
@@ -5232,13 +5234,13 @@ module.exports = {
 
 /***/ }),
 
-/***/ 2547:
+/***/ 2751:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
-const fs = __nccwpck_require__(7856)
-const { checkPath } = __nccwpck_require__(1528)
+const fs = __nccwpck_require__(1176)
+const { checkPath } = __nccwpck_require__(9907)
 
 const getMode = options => {
   const defaults = { mode: 0o777 }
@@ -5267,7 +5269,7 @@ module.exports.makeDirSync = (dir, options) => {
 
 /***/ }),
 
-/***/ 1528:
+/***/ 9907:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
@@ -5296,33 +5298,33 @@ module.exports.checkPath = function checkPath (pth) {
 
 /***/ }),
 
-/***/ 8901:
+/***/ 1497:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
-const u = (__nccwpck_require__(838).fromCallback)
+const u = (__nccwpck_require__(9046).fromCallback)
 module.exports = {
-  move: u(__nccwpck_require__(4050)),
-  moveSync: __nccwpck_require__(8346)
+  move: u(__nccwpck_require__(2231)),
+  moveSync: __nccwpck_require__(2047)
 }
 
 
 /***/ }),
 
-/***/ 8346:
+/***/ 2047:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
-const fs = __nccwpck_require__(2380)
+const fs = __nccwpck_require__(7758)
 const path = __nccwpck_require__(1017)
-const copySync = (__nccwpck_require__(5403).copySync)
-const removeSync = (__nccwpck_require__(4119).removeSync)
-const mkdirpSync = (__nccwpck_require__(568).mkdirpSync)
-const stat = __nccwpck_require__(2320)
+const copySync = (__nccwpck_require__(1335).copySync)
+const removeSync = (__nccwpck_require__(7357).removeSync)
+const mkdirpSync = (__nccwpck_require__(8605).mkdirpSync)
+const stat = __nccwpck_require__(3901)
 
 function moveSync (src, dest, opts) {
   opts = opts || {}
@@ -5373,19 +5375,19 @@ module.exports = moveSync
 
 /***/ }),
 
-/***/ 4050:
+/***/ 2231:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
-const fs = __nccwpck_require__(2380)
+const fs = __nccwpck_require__(7758)
 const path = __nccwpck_require__(1017)
-const copy = (__nccwpck_require__(5403).copy)
-const remove = (__nccwpck_require__(4119).remove)
-const mkdirp = (__nccwpck_require__(568).mkdirp)
-const pathExists = (__nccwpck_require__(5525).pathExists)
-const stat = __nccwpck_require__(2320)
+const copy = (__nccwpck_require__(1335).copy)
+const remove = (__nccwpck_require__(7357).remove)
+const mkdirp = (__nccwpck_require__(8605).mkdirp)
+const pathExists = (__nccwpck_require__(3835).pathExists)
+const stat = __nccwpck_require__(3901)
 
 function move (src, dest, opts, cb) {
   if (typeof opts === 'function') {
@@ -5456,17 +5458,17 @@ module.exports = move
 
 /***/ }),
 
-/***/ 1923:
+/***/ 1832:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
-const u = (__nccwpck_require__(838).fromCallback)
-const fs = __nccwpck_require__(2380)
+const u = (__nccwpck_require__(9046).fromCallback)
+const fs = __nccwpck_require__(7758)
 const path = __nccwpck_require__(1017)
-const mkdir = __nccwpck_require__(568)
-const pathExists = (__nccwpck_require__(5525).pathExists)
+const mkdir = __nccwpck_require__(8605)
+const pathExists = (__nccwpck_require__(3835).pathExists)
 
 function outputFile (file, data, encoding, callback) {
   if (typeof encoding === 'function') {
@@ -5504,13 +5506,13 @@ module.exports = {
 
 /***/ }),
 
-/***/ 5525:
+/***/ 3835:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
-const u = (__nccwpck_require__(838).fromPromise)
-const fs = __nccwpck_require__(7856)
+const u = (__nccwpck_require__(9046).fromPromise)
+const fs = __nccwpck_require__(1176)
 
 function pathExists (path) {
   return fs.access(path).then(() => true).catch(() => false)
@@ -5524,15 +5526,15 @@ module.exports = {
 
 /***/ }),
 
-/***/ 4119:
+/***/ 7357:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
-const fs = __nccwpck_require__(2380)
-const u = (__nccwpck_require__(838).fromCallback)
-const rimraf = __nccwpck_require__(9076)
+const fs = __nccwpck_require__(7758)
+const u = (__nccwpck_require__(9046).fromCallback)
+const rimraf = __nccwpck_require__(8761)
 
 function remove (path, callback) {
   // Node 14.14.0+
@@ -5554,13 +5556,13 @@ module.exports = {
 
 /***/ }),
 
-/***/ 9076:
+/***/ 8761:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
-const fs = __nccwpck_require__(2380)
+const fs = __nccwpck_require__(7758)
 const path = __nccwpck_require__(1017)
 const assert = __nccwpck_require__(9491)
 
@@ -5864,13 +5866,13 @@ rimraf.sync = rimrafSync
 
 /***/ }),
 
-/***/ 2320:
+/***/ 3901:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
-const fs = __nccwpck_require__(7856)
+const fs = __nccwpck_require__(1176)
 const path = __nccwpck_require__(1017)
 const util = __nccwpck_require__(3837)
 
@@ -6026,13 +6028,13 @@ module.exports = {
 
 /***/ }),
 
-/***/ 6543:
+/***/ 2548:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
-const fs = __nccwpck_require__(2380)
+const fs = __nccwpck_require__(7758)
 
 function utimesMillis (path, atime, mtime, callback) {
   // if (!HAS_MILLIS_RES) return fs.utimes(path, atime, mtime, callback)
@@ -6060,7 +6062,7 @@ module.exports = {
 
 /***/ }),
 
-/***/ 3452:
+/***/ 7356:
 /***/ ((module) => {
 
 "use strict";
@@ -6091,13 +6093,13 @@ function clone (obj) {
 
 /***/ }),
 
-/***/ 2380:
+/***/ 7758:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var fs = __nccwpck_require__(7147)
-var polyfills = __nccwpck_require__(9976)
-var legacy = __nccwpck_require__(1458)
-var clone = __nccwpck_require__(3452)
+var polyfills = __nccwpck_require__(263)
+var legacy = __nccwpck_require__(3086)
+var clone = __nccwpck_require__(7356)
 
 var util = __nccwpck_require__(3837)
 
@@ -6546,7 +6548,7 @@ function retry () {
 
 /***/ }),
 
-/***/ 1458:
+/***/ 3086:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var Stream = (__nccwpck_require__(2781).Stream)
@@ -6671,7 +6673,7 @@ function legacy (fs) {
 
 /***/ }),
 
-/***/ 9976:
+/***/ 263:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var constants = __nccwpck_require__(2057)
@@ -7033,17 +7035,17 @@ function patch (fs) {
 
 /***/ }),
 
-/***/ 1927:
+/***/ 6160:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 let _fs
 try {
-  _fs = __nccwpck_require__(2380)
+  _fs = __nccwpck_require__(7758)
 } catch (_) {
   _fs = __nccwpck_require__(7147)
 }
-const universalify = __nccwpck_require__(838)
-const { stringify, stripBom } = __nccwpck_require__(2681)
+const universalify = __nccwpck_require__(9046)
+const { stringify, stripBom } = __nccwpck_require__(5902)
 
 async function _readFile (file, options = {}) {
   if (typeof options === 'string') {
@@ -7128,7 +7130,7 @@ module.exports = jsonfile
 
 /***/ }),
 
-/***/ 2681:
+/***/ 5902:
 /***/ ((module) => {
 
 function stringify (obj, { EOL = '\n', finalEOL = true, replacer = null, spaces } = {}) {
@@ -7149,7 +7151,7 @@ module.exports = { stringify, stripBom }
 
 /***/ }),
 
-/***/ 5662:
+/***/ 467:
 /***/ ((module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -7162,7 +7164,7 @@ function _interopDefault (ex) { return (ex && (typeof ex === 'object') && 'defau
 var Stream = _interopDefault(__nccwpck_require__(2781));
 var http = _interopDefault(__nccwpck_require__(3685));
 var Url = _interopDefault(__nccwpck_require__(7310));
-var whatwgUrl = _interopDefault(__nccwpck_require__(3552));
+var whatwgUrl = _interopDefault(__nccwpck_require__(8665));
 var https = _interopDefault(__nccwpck_require__(5687));
 var zlib = _interopDefault(__nccwpck_require__(9796));
 
@@ -7315,7 +7317,7 @@ FetchError.prototype.name = 'FetchError';
 
 let convert;
 try {
-	convert = (__nccwpck_require__(4565).convert);
+	convert = (__nccwpck_require__(2877).convert);
 } catch (e) {}
 
 const INTERNALS = Symbol('Body internals');
@@ -8854,7 +8856,7 @@ exports.FetchError = FetchError;
 
 /***/ }),
 
-/***/ 9079:
+/***/ 5911:
 /***/ ((module, exports) => {
 
 exports = module.exports = SemVer
@@ -10457,7 +10459,7 @@ function coerce (version, options) {
 
 /***/ }),
 
-/***/ 816:
+/***/ 4256:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
@@ -10658,15 +10660,15 @@ module.exports.PROCESSING_OPTIONS = PROCESSING_OPTIONS;
 
 /***/ }),
 
-/***/ 2264:
+/***/ 4294:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
-module.exports = __nccwpck_require__(9985);
+module.exports = __nccwpck_require__(4219);
 
 
 /***/ }),
 
-/***/ 9985:
+/***/ 4219:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -10938,7 +10940,7 @@ exports.debug = debug; // for test
 
 /***/ }),
 
-/***/ 838:
+/***/ 9046:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -10970,7 +10972,7 @@ exports.fromPromise = function (fn) {
 
 /***/ }),
 
-/***/ 3160:
+/***/ 5840:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -11034,29 +11036,29 @@ Object.defineProperty(exports, "parse", ({
   }
 }));
 
-var _v = _interopRequireDefault(__nccwpck_require__(9374));
+var _v = _interopRequireDefault(__nccwpck_require__(8628));
 
-var _v2 = _interopRequireDefault(__nccwpck_require__(8377));
+var _v2 = _interopRequireDefault(__nccwpck_require__(6409));
 
-var _v3 = _interopRequireDefault(__nccwpck_require__(3884));
+var _v3 = _interopRequireDefault(__nccwpck_require__(5122));
 
-var _v4 = _interopRequireDefault(__nccwpck_require__(6959));
+var _v4 = _interopRequireDefault(__nccwpck_require__(9120));
 
-var _nil = _interopRequireDefault(__nccwpck_require__(590));
+var _nil = _interopRequireDefault(__nccwpck_require__(5332));
 
-var _version = _interopRequireDefault(__nccwpck_require__(6229));
+var _version = _interopRequireDefault(__nccwpck_require__(1595));
 
-var _validate = _interopRequireDefault(__nccwpck_require__(2525));
+var _validate = _interopRequireDefault(__nccwpck_require__(6900));
 
-var _stringify = _interopRequireDefault(__nccwpck_require__(3192));
+var _stringify = _interopRequireDefault(__nccwpck_require__(8950));
 
-var _parse = _interopRequireDefault(__nccwpck_require__(1148));
+var _parse = _interopRequireDefault(__nccwpck_require__(2746));
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
 /***/ }),
 
-/***/ 8981:
+/***/ 4569:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -11086,7 +11088,7 @@ exports["default"] = _default;
 
 /***/ }),
 
-/***/ 590:
+/***/ 5332:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -11101,7 +11103,7 @@ exports["default"] = _default;
 
 /***/ }),
 
-/***/ 1148:
+/***/ 2746:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -11112,7 +11114,7 @@ Object.defineProperty(exports, "__esModule", ({
 }));
 exports["default"] = void 0;
 
-var _validate = _interopRequireDefault(__nccwpck_require__(2525));
+var _validate = _interopRequireDefault(__nccwpck_require__(6900));
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
@@ -11153,7 +11155,7 @@ exports["default"] = _default;
 
 /***/ }),
 
-/***/ 9673:
+/***/ 814:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -11168,7 +11170,7 @@ exports["default"] = _default;
 
 /***/ }),
 
-/***/ 3111:
+/***/ 807:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -11199,7 +11201,7 @@ function rng() {
 
 /***/ }),
 
-/***/ 6649:
+/***/ 5274:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -11229,7 +11231,7 @@ exports["default"] = _default;
 
 /***/ }),
 
-/***/ 3192:
+/***/ 8950:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -11240,7 +11242,7 @@ Object.defineProperty(exports, "__esModule", ({
 }));
 exports["default"] = void 0;
 
-var _validate = _interopRequireDefault(__nccwpck_require__(2525));
+var _validate = _interopRequireDefault(__nccwpck_require__(6900));
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
@@ -11275,7 +11277,7 @@ exports["default"] = _default;
 
 /***/ }),
 
-/***/ 9374:
+/***/ 8628:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -11286,9 +11288,9 @@ Object.defineProperty(exports, "__esModule", ({
 }));
 exports["default"] = void 0;
 
-var _rng = _interopRequireDefault(__nccwpck_require__(3111));
+var _rng = _interopRequireDefault(__nccwpck_require__(807));
 
-var _stringify = _interopRequireDefault(__nccwpck_require__(3192));
+var _stringify = _interopRequireDefault(__nccwpck_require__(8950));
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
@@ -11389,7 +11391,7 @@ exports["default"] = _default;
 
 /***/ }),
 
-/***/ 8377:
+/***/ 6409:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -11400,9 +11402,9 @@ Object.defineProperty(exports, "__esModule", ({
 }));
 exports["default"] = void 0;
 
-var _v = _interopRequireDefault(__nccwpck_require__(2125));
+var _v = _interopRequireDefault(__nccwpck_require__(5998));
 
-var _md = _interopRequireDefault(__nccwpck_require__(8981));
+var _md = _interopRequireDefault(__nccwpck_require__(4569));
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
@@ -11412,7 +11414,7 @@ exports["default"] = _default;
 
 /***/ }),
 
-/***/ 2125:
+/***/ 5998:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -11424,9 +11426,9 @@ Object.defineProperty(exports, "__esModule", ({
 exports["default"] = _default;
 exports.URL = exports.DNS = void 0;
 
-var _stringify = _interopRequireDefault(__nccwpck_require__(3192));
+var _stringify = _interopRequireDefault(__nccwpck_require__(8950));
 
-var _parse = _interopRequireDefault(__nccwpck_require__(1148));
+var _parse = _interopRequireDefault(__nccwpck_require__(2746));
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
@@ -11497,7 +11499,7 @@ function _default(name, version, hashfunc) {
 
 /***/ }),
 
-/***/ 3884:
+/***/ 5122:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -11508,9 +11510,9 @@ Object.defineProperty(exports, "__esModule", ({
 }));
 exports["default"] = void 0;
 
-var _rng = _interopRequireDefault(__nccwpck_require__(3111));
+var _rng = _interopRequireDefault(__nccwpck_require__(807));
 
-var _stringify = _interopRequireDefault(__nccwpck_require__(3192));
+var _stringify = _interopRequireDefault(__nccwpck_require__(8950));
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
@@ -11541,7 +11543,7 @@ exports["default"] = _default;
 
 /***/ }),
 
-/***/ 6959:
+/***/ 9120:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -11552,9 +11554,9 @@ Object.defineProperty(exports, "__esModule", ({
 }));
 exports["default"] = void 0;
 
-var _v = _interopRequireDefault(__nccwpck_require__(2125));
+var _v = _interopRequireDefault(__nccwpck_require__(5998));
 
-var _sha = _interopRequireDefault(__nccwpck_require__(6649));
+var _sha = _interopRequireDefault(__nccwpck_require__(5274));
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
@@ -11564,7 +11566,7 @@ exports["default"] = _default;
 
 /***/ }),
 
-/***/ 2525:
+/***/ 6900:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -11575,7 +11577,7 @@ Object.defineProperty(exports, "__esModule", ({
 }));
 exports["default"] = void 0;
 
-var _regex = _interopRequireDefault(__nccwpck_require__(9673));
+var _regex = _interopRequireDefault(__nccwpck_require__(814));
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
@@ -11588,7 +11590,7 @@ exports["default"] = _default;
 
 /***/ }),
 
-/***/ 6229:
+/***/ 1595:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -11599,7 +11601,7 @@ Object.defineProperty(exports, "__esModule", ({
 }));
 exports["default"] = void 0;
 
-var _validate = _interopRequireDefault(__nccwpck_require__(2525));
+var _validate = _interopRequireDefault(__nccwpck_require__(6900));
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
@@ -11616,7 +11618,7 @@ exports["default"] = _default;
 
 /***/ }),
 
-/***/ 4441:
+/***/ 4886:
 /***/ ((module) => {
 
 "use strict";
@@ -11813,12 +11815,12 @@ conversions["RegExp"] = function (V, opts) {
 
 /***/ }),
 
-/***/ 2219:
+/***/ 7537:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
 
-const usm = __nccwpck_require__(1825);
+const usm = __nccwpck_require__(2158);
 
 exports.implementation = class URLImpl {
   constructor(constructorArgs) {
@@ -12021,15 +12023,15 @@ exports.implementation = class URLImpl {
 
 /***/ }),
 
-/***/ 6618:
+/***/ 3394:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
-const conversions = __nccwpck_require__(4441);
-const utils = __nccwpck_require__(4652);
-const Impl = __nccwpck_require__(2219);
+const conversions = __nccwpck_require__(4886);
+const utils = __nccwpck_require__(3185);
+const Impl = __nccwpck_require__(7537);
 
 const impl = utils.implSymbol;
 
@@ -12225,32 +12227,32 @@ module.exports = {
 
 /***/ }),
 
-/***/ 3552:
+/***/ 8665:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
 
 
-exports.URL = __nccwpck_require__(6618)["interface"];
-exports.serializeURL = __nccwpck_require__(1825).serializeURL;
-exports.serializeURLOrigin = __nccwpck_require__(1825).serializeURLOrigin;
-exports.basicURLParse = __nccwpck_require__(1825).basicURLParse;
-exports.setTheUsername = __nccwpck_require__(1825).setTheUsername;
-exports.setThePassword = __nccwpck_require__(1825).setThePassword;
-exports.serializeHost = __nccwpck_require__(1825).serializeHost;
-exports.serializeInteger = __nccwpck_require__(1825).serializeInteger;
-exports.parseURL = __nccwpck_require__(1825).parseURL;
+exports.URL = __nccwpck_require__(3394)["interface"];
+exports.serializeURL = __nccwpck_require__(2158).serializeURL;
+exports.serializeURLOrigin = __nccwpck_require__(2158).serializeURLOrigin;
+exports.basicURLParse = __nccwpck_require__(2158).basicURLParse;
+exports.setTheUsername = __nccwpck_require__(2158).setTheUsername;
+exports.setThePassword = __nccwpck_require__(2158).setThePassword;
+exports.serializeHost = __nccwpck_require__(2158).serializeHost;
+exports.serializeInteger = __nccwpck_require__(2158).serializeInteger;
+exports.parseURL = __nccwpck_require__(2158).parseURL;
 
 
 /***/ }),
 
-/***/ 1825:
+/***/ 2158:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 const punycode = __nccwpck_require__(5477);
-const tr46 = __nccwpck_require__(816);
+const tr46 = __nccwpck_require__(4256);
 
 const specialSchemes = {
   ftp: 21,
@@ -13549,7 +13551,7 @@ module.exports.parseURL = function (input, options) {
 
 /***/ }),
 
-/***/ 4652:
+/***/ 3185:
 /***/ ((module) => {
 
 "use strict";
@@ -13577,7 +13579,7 @@ module.exports.implForWrapper = function (wrapper) {
 
 /***/ }),
 
-/***/ 4565:
+/***/ 2877:
 /***/ ((module) => {
 
 module.exports = eval("require")("encoding");
@@ -13787,7 +13789,7 @@ module.exports = JSON.parse('[[[0,44],"disallowed_STD3_valid"],[[45,46],"valid"]
 /******/ 	// startup
 /******/ 	// Load entry module and return exports
 /******/ 	// This entry module is referenced by other modules so it can't be inlined
-/******/ 	var __webpack_exports__ = __nccwpck_require__(7648);
+/******/ 	var __webpack_exports__ = __nccwpck_require__(2932);
 /******/ 	module.exports = __webpack_exports__;
 /******/ 	
 /******/ })()

--- a/index.js
+++ b/index.js
@@ -1,16 +1,16 @@
-const core = require('@actions/core');
-const tc = require('@actions/tool-cache');
-const os = require('os');
-const path = require('path');
-const fs = require('fs-extra');
-const fetch = require('node-fetch');
+const core = require("@actions/core");
+const tc = require("@actions/tool-cache");
+const os = require("os");
+const path = require("path");
+const fs = require("fs-extra");
+const fetch = require("node-fetch");
 
 async function setup() {
-  const version = core.getInput('version');
-  const apiKey = core.getInput('baselime-api-key');
+  const version = core.getInput("version");
+  const apiKey = core.getInput("baselime-api-key");
 
   // Download the specific version of the tool, e.g. as a tarball
-  const { url } = getDownloadURL(version || await getLatestCLIVersion());
+  const { url } = getDownloadURL(version || (await getLatestCLIVersion()));
   const pathToTarball = await tc.downloadTool(url);
 
   // Extract the tarball onto the runner
@@ -36,16 +36,18 @@ function getPath() {
 
 async function getLatestCLIVersion() {
   try {
-    const res = await (await fetch("https://api.github.com/repos/baselime/cli/releases/latest")).json();
+    const res = await (
+      await fetch("https://api.github.com/repos/baselime/cli/releases/latest")
+    ).json();
     return res.tag_name.replace("v", "");
   } catch (error) {
-    console.error("There was an error getting the latest version of the Baselime CLI", { error });
-    throw error;
+    core.setFailed(
+      `There was an error getting the latest version of the Baselime CLI ${error}`
+    );
   }
 }
 
-
-module.exports = setup
+module.exports = setup;
 
 if (require.main === module) {
   setup();

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,9 @@
         "@actions/tool-cache": "^2.0.1",
         "fs-extra": "^10.1.0",
         "node-fetch": "^2.6.7"
+      },
+      "devDependencies": {
+        "@vercel/ncc": "^0.34.0"
       }
     },
     "node_modules/@actions/core": {
@@ -178,6 +181,15 @@
       "integrity": "sha512-eJ2jbzjdijiL3B4PrSQaSjuF2sPEQPVCPzBvTHJD9Nz+9dw2SGH4K4xeQJ77YfTq5bRQ+bD8wT11JbeDPmxmGg==",
       "dependencies": {
         "@octokit/openapi-types": "^12.11.0"
+      }
+    },
+    "node_modules/@vercel/ncc": {
+      "version": "0.34.0",
+      "resolved": "https://registry.npmjs.org/@vercel/ncc/-/ncc-0.34.0.tgz",
+      "integrity": "sha512-G9h5ZLBJ/V57Ou9vz5hI8pda/YQX5HQszCs3AmIus3XzsmRn/0Ptic5otD3xVST8QLKk7AMk7AqpsyQGN7MZ9A==",
+      "dev": true,
+      "bin": {
+        "ncc": "dist/ncc/cli.js"
       }
     },
     "node_modules/before-after-hook": {
@@ -472,6 +484,12 @@
       "requires": {
         "@octokit/openapi-types": "^12.11.0"
       }
+    },
+    "@vercel/ncc": {
+      "version": "0.34.0",
+      "resolved": "https://registry.npmjs.org/@vercel/ncc/-/ncc-0.34.0.tgz",
+      "integrity": "sha512-G9h5ZLBJ/V57Ou9vz5hI8pda/YQX5HQszCs3AmIus3XzsmRn/0Ptic5otD3xVST8QLKk7AMk7AqpsyQGN7MZ9A==",
+      "dev": true
     },
     "before-after-hook": {
       "version": "2.2.2",

--- a/package.json
+++ b/package.json
@@ -28,5 +28,8 @@
     "@actions/tool-cache": "^2.0.1",
     "fs-extra": "^10.1.0",
     "node-fetch": "^2.6.7"
+  },
+  "devDependencies": {
+    "@vercel/ncc": "^0.34.0"
   }
 }


### PR DESCRIPTION
This is a simple PR. Just to facilitate DX and to return the correct exit code when the action failed.

- Return the `core.setFailed()` when and exception is trowed
- Add the `ncc` dependency directly on the project.

For testing your action on local, you can try this [https://github.com/nektos/act](https://github.com/nektos/act )