### PR TITLE
Update action.yml to use node 20 following GitHub deprecation

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -11,5 +11,5 @@ inputs:
     description: 'Version of the Baselime CLI to install'
     required: false
 runs:
-  using: 'node16'
+  using: 'node20'
   main: 'dist/index.js'


### PR DESCRIPTION

<img width="1914" alt="image" src="https://github.com/baselime/action-setup-baselime/assets/1418870/da6a16d3-fde8-4886-88be-3198ce238007">


https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/